### PR TITLE
Metadata updater

### DIFF
--- a/streamer/audio/metadataUpdate.go
+++ b/streamer/audio/metadataUpdate.go
@@ -1,14 +1,4 @@
-
-cmd commands are 
-"ffmpeg -i "orignalfile.extension" -map_metadata -1 -c:v copy -c:a copy "tempfile.extension"" - Wipes Metadata, writes to a tempfile
-"mv/move "tempfile.extension" "orignalfile.extension
-"ffmpeg -i "tempfile.extension" -metadata artist="Oasis" -metadata title="Falling Down" -metadata album="Dig Out Your Soul" -codec copy "orignalfile.extension""#
-(you need to delete the temp file here)
-
-
-// You can edit this code!
-// Click here and start typing.
-package main
+package audio
 
 import (
 	"fmt"
@@ -21,9 +11,8 @@ func MetadataAssign(tags []string, file string) {
 	// building string sequentially to avoid unwanted whitespace //
 	metadataTags := []string{"artist=", "title=", "album="}
 	var arg strings.Builder
-
-	fmt.Println(fmt.Sprintf(`%q`, tags[1]))
-
+	
+	// stripping tags //
 	arg.WriteString("-i ")
 	arg.WriteString(fmt.Sprintf(`%q`, file))
 	arg.WriteString(" -map_metadata -1 -c:v copy -c:a copy ")
@@ -31,24 +20,15 @@ func MetadataAssign(tags []string, file string) {
 	arg.WriteString(file)
 	arg.WriteString("\"")
 	placeholder1 := exec.Command("ffmpeg", arg.String())
-	fmt.Println(placeholder1)
-
 	arg.Reset()
 
-	arg.WriteString("mv ")
+	fmt.Println(fmt.Sprintf(`%q`, tags[1]))
+
+	// writing tags to new perm file from temp // 
+	arg.WriteString("-i ")
 	arg.WriteString("\"temp")
 	arg.WriteString(file)
 	arg.WriteString("\" ")
-	arg.WriteString(fmt.Sprintf(`%q`, file))
-	placeholder2 := exec.Command(arg.String())
-	fmt.Println(placeholder2)
-
-	arg.Reset()
-
-	fmt.Println(arg)
-
-	arg.WriteString("-i ")
-	arg.WriteString(fmt.Sprintf(`%q`, file))
 	arg.WriteString(" -c:a copy")
 	for n := 0; n < len(tags); n++ {
 		arg.WriteString(" -metadata ")
@@ -58,5 +38,14 @@ func MetadataAssign(tags []string, file string) {
 	arg.WriteString(" -o ")
 	arg.WriteString(fmt.Sprintf(`%q`, file))
 	placeholder3 := exec.Command("ffmpeg", arg.String())
-	fmt.Println(placeholder3)
+
+	arg.Reset()
+
+	// remove temp file //
+	arg.WriteString("rm ")
+	arg.WriteString("\"temp")
+	arg.WriteString(file)
+	arg.WriteString("\" ")
+	placeholder2 := exec.Command(arg.String())
+
 }

--- a/streamer/audio/metadataUpdate.go
+++ b/streamer/audio/metadataUpdate.go
@@ -1,0 +1,62 @@
+
+cmd commands are 
+"ffmpeg -i "orignalfile.extension" -map_metadata -1 -c:v copy -c:a copy "tempfile.extension"" - Wipes Metadata, writes to a tempfile
+"mv/move "tempfile.extension" "orignalfile.extension
+"ffmpeg -i "tempfile.extension" -metadata artist="Oasis" -metadata title="Falling Down" -metadata album="Dig Out Your Soul" -codec copy "orignalfile.extension""#
+(you need to delete the temp file here)
+
+
+// You can edit this code!
+// Click here and start typing.
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// assuming filename is passed into function with tags
+func MetadataAssign(tags []string, file string) {
+	// building string sequentially to avoid unwanted whitespace //
+	metadataTags := []string{"artist=", "title=", "album="}
+	var arg strings.Builder
+
+	fmt.Println(fmt.Sprintf(`%q`, tags[1]))
+
+	arg.WriteString("-i ")
+	arg.WriteString(fmt.Sprintf(`%q`, file))
+	arg.WriteString(" -map_metadata -1 -c:v copy -c:a copy ")
+	arg.WriteString("\"temp")
+	arg.WriteString(file)
+	arg.WriteString("\"")
+	placeholder1 := exec.Command("ffmpeg", arg.String())
+	fmt.Println(placeholder1)
+
+	arg.Reset()
+
+	arg.WriteString("mv ")
+	arg.WriteString("\"temp")
+	arg.WriteString(file)
+	arg.WriteString("\" ")
+	arg.WriteString(fmt.Sprintf(`%q`, file))
+	placeholder2 := exec.Command(arg.String())
+	fmt.Println(placeholder2)
+
+	arg.Reset()
+
+	fmt.Println(arg)
+
+	arg.WriteString("-i ")
+	arg.WriteString(fmt.Sprintf(`%q`, file))
+	arg.WriteString(" -c:a copy")
+	for n := 0; n < len(tags); n++ {
+		arg.WriteString(" -metadata ")
+		arg.WriteString(metadataTags[n])
+		arg.WriteString(fmt.Sprintf(`%q`, tags[n]))
+	}
+	arg.WriteString(" -o ")
+	arg.WriteString(fmt.Sprintf(`%q`, file))
+	placeholder3 := exec.Command("ffmpeg", arg.String())
+	fmt.Println(placeholder3)
+}


### PR DESCRIPTION
This'll probably need to be looked at, the code hasn't been tested on a server but does at least compile on Go's testing site. Edited the process for commands of ffmpeg since it's much simplier to use the temp file as a way to onboard the updating tags and then remove it, it's an empty file without any tags and a work-around for ffmpeg not allowing you to overwrite even when updating metadata.
Sorry, this is probably awful, but it should at least detail the process and steps.