### PR TITLE
website/faves: return more faves when using "&dl=true"

### DIFF
--- a/website/public/faves.go
+++ b/website/public/faves.go
@@ -56,7 +56,17 @@ func NewFavesInput(ss radio.SongStorage, rs radio.RequestStorage, r *http.Reques
 	var faves []radio.Song
 	var faveCount int64
 	if nickname != "" { // only ask for faves if we have a nickname
-		faves, faveCount, err = ss.FavoritesOf(nickname, favesPageSize, offset)
+	
+		isDownload := r.FormValue("dl") == "true"
+		
+		// return up to 1 million faves if dl=true
+		if isDownload {
+			faves, faveCount, err = ss.FavoritesOf(nickname, 1000000, 0)
+		} else {
+			// otherwise use pagination
+			faves, faveCount, err = ss.FavoritesOf(nickname, favesPageSize, offset)
+		}
+		
 		if err != nil {
 			return nil, errors.E(op, err)
 		}


### PR DESCRIPTION
returns 1 million faves if `&dl=true`

fixes https://github.com/R-a-dio/valkyrie/issues/274

not a serious fix, just something to get @Wessie to stop being lazy (not sure it really even works, only tested with around 110 faves, but it did get all of those vs only 100 without the change)